### PR TITLE
Fix mind lookup block arg ordering

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -213,8 +213,8 @@ Blockly.Mindustry['mind_lookup'] = function (block) {
     block,
     'lookup',
     ['field', 'TYPE'],
-    ['value', 'INDEX'],
-    ['field', 'DEST']
+    ['field', 'DEST'],
+    ['value', 'INDEX']
   );
 };
 


### PR DESCRIPTION
# Input:

![image](https://github.com/user-attachments/assets/a5de5be0-eb54-4b21-8213-271eaa1b9b88)

```xml
<xml xmlns="https://developers.google.com/blockly/xml"><block type="mind_lookup" id="HKPm*Z5s/5D$c+u8oE^i" x="629" y="252"><field name="DEST">result</field><field name="TYPE">block</field><value name="INDEX"><shadow type="var_block_text" id="OM4`lz14G7e%iC-S_5eD"><field name="VALUE">0</field></shadow></value></block></xml>
```

# Old:

![image](https://github.com/user-attachments/assets/0f57c194-9060-49b7-9c5a-8aa00daca50c)

```
lookup block 0 result
```

# New:

![image](https://github.com/user-attachments/assets/f7fef40f-dc99-41c7-bdf6-be71c4523db2)

```
lookup block result 0
```
